### PR TITLE
Fix resume download functionality

### DIFF
--- a/components/ResumePreview.js
+++ b/components/ResumePreview.js
@@ -7,7 +7,7 @@ const ResumePreview = forwardRef(({ data }, ref) => {
 
   if (template === 'modern') {
     return (
-      <div  className="max-w-[21cm] mx-auto bg-white text-slate-900 font-sans">
+      <div ref={ref}  className="max-w-[21cm] mx-auto bg-white text-slate-900 font-sans">
         {/* Header */}
         <header className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white p-8 rounded-t-lg">
           <h1 className="text-3xl font-bold mb-2">{p.name || 'Your Full Name'}</h1>
@@ -105,7 +105,7 @@ const ResumePreview = forwardRef(({ data }, ref) => {
 
   if (template === 'minimal') {
     return (
-      <div  className="max-w-[21cm] mx-auto bg-white text-slate-900 font-sans">
+      <div ref={ref}  className="max-w-[21cm] mx-auto bg-white text-slate-900 font-sans">
         {/* Header */}
         <header className="border-b-4 border-slate-900 pb-6 mb-8">
           <h1 className="text-4xl font-light mb-2">{p.name || 'Your Full Name'}</h1>


### PR DESCRIPTION
Attach the `ref` to the root element of all `ResumePreview` templates to enable PDF download functionality for all designs.

The `handleDownload` function relies on `previewRef.current` to capture the resume preview. Previously, the `ref` was only applied to the 'classic' template's root element, causing the download to fail when 'modern' or 'minimal' templates were selected as `previewRef.current` would be null. This change ensures `html2canvas` can correctly access the preview element regardless of the chosen template.

---
<a href="https://cursor.com/background-agent?bcId=bc-12a961c5-f06f-41b3-bf5d-b00cfba45ca1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12a961c5-f06f-41b3-bf5d-b00cfba45ca1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

